### PR TITLE
chmod 0755 overwrite file permissions

### DIFF
--- a/collective/recipe/modwsgi/__init__.py
+++ b/collective/recipe/modwsgi/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import stat
 import zc.buildout
 from zc.recipe.egg.egg import Eggs
 
@@ -59,7 +60,9 @@ class Recipe:
         f=open(target, "wt")
         f.write(output)
         f.close()
-        os.chmod(target, 0755)
+
+        exec_mask=stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+        os.chmod(target, os.stat(target).st_mode | exec_mask)
         self.options.created(target)
 
         return self.options.created()

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,7 +3,8 @@ Changelog
 
 1.3 - unreleased
 ----------------
-
+* don't overwrite existing file permissions when setting execute permission.
+  [fredj]
 
 1.2 - August 7, 2009
 --------------------


### PR DESCRIPTION
Hello,

The problem is that this chmod overwrite the file permissions sets via
the umask. 
My umask is 002, so the new files are: -rw-rw-r--
and when the file is chmod 0755, the group write permission is lost.

BTW, if you need help to develop/maintain this recipe I'll be happy to contribute.

Regards,

fredj
