### PR TITLE
do not use paster script for python2.6 and up

### DIFF
--- a/collective/recipe/modwsgi/__init__.py
+++ b/collective/recipe/modwsgi/__init__.py
@@ -16,7 +16,12 @@ for path in reversed(syspaths):
 
 
 from paste.deploy import loadapp
-from paste.script.util.logging_config import fileConfig
+
+if sys.version_info >= (2, 6):
+    from logging.config import fileConfig
+else:
+    from paste.script.util.logging_config import fileConfig
+
 
 configfile="%(config)s"
 fileConfig(configfile)


### PR DESCRIPTION
latest pyramid doesnt depend on pastescript, and pastescript wont work on py3
so its probably better to drop import from paste.script
