### PR TITLE
Add config variable for app_name

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -13,6 +13,7 @@ which creates a WSGI script mod_python can use::
     [mywsgiapp]
     recipe = collective.recipe.modwsgi
     eggs = mywsgiapp
+    app_name = main
     config-file = ${buildout:directory}/production.ini
 
 This will create a small python script in parts/mywsgiapp called

--- a/collective/recipe/modwsgi/__init__.py
+++ b/collective/recipe/modwsgi/__init__.py
@@ -29,7 +29,7 @@ try:
     fileConfig(configfile)
 except ConfigParser.NoSectionError:
     pass
-application = loadapp("config:" + configfile)
+application = loadapp("config:" + configfile, name=%(app_name)s)
 """
 
 
@@ -53,9 +53,16 @@ class Recipe:
         extra_paths = extra_paths.split()
         path.extend(extra_paths)
 
+        # Do not put None into 'quotes'
+        # Everything else should be a string pointing to a pipeline
+        app_name = self.options.get('app_name')
+        if app_name is not None:
+            app_name = '"%s"' % app_name
+
         output = WRAPPER_TEMPLATE % dict(
             config=self.options["config-file"],
-            syspath=",\n    ".join((repr(p) for p in path))
+            syspath=",\n    ".join((repr(p) for p in path)),
+            app_name=app_name
             )
 
         location = os.path.join(self.buildout["buildout"]["parts-directory"],


### PR DESCRIPTION
The idea is make it configurable which pipeline should be loaded.

I had one configfile with different applications requiring different pipelines. 
However some parts of these applications are shared like filter, logging, ....

Currently this recipe loads only the 'main' pipeline, in my case this means three different configfiles with a lot of duplicated parts. 

The change on the code allows it to define inside the buildout.cfg which pipeline should be used.
If the option is not set the old behavior still applies. 
