### PR TITLE
Minor changes to make recipe Python 3.x compatible.

### DIFF
--- a/collective/recipe/modwsgi/__init__.py
+++ b/collective/recipe/modwsgi/__init__.py
@@ -5,7 +5,10 @@ import zc.buildout
 from zc.recipe.egg.egg import Eggs
 
 WRAPPER_TEMPLATE = """\
-import ConfigParser
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
 import sys
 syspaths = [
     %(syspath)s,
@@ -27,7 +30,7 @@ else:
 configfile = "%(config)s"
 try:
     fileConfig(configfile)
-except ConfigParser.NoSectionError:
+except configparser.NoSectionError:
     pass
 application = loadapp("config:" + configfile, name=%(app_name)s)
 """

--- a/collective/recipe/modwsgi/__init__.py
+++ b/collective/recipe/modwsgi/__init__.py
@@ -33,7 +33,7 @@ application = loadapp("config:" + configfile, name=%(app_name)s)
 """
 
 
-class Recipe:
+class Recipe(object):
     def __init__(self, buildout, name, options):
         self.buildout = buildout
         self.name = name


### PR DESCRIPTION
In template, try to import Python 3.x `configparser` and if that fails fallback to Python 2.x `ConfigParser`.
