### PR TITLE
Handle broken symlinks when using the target option

### DIFF
--- a/collective/recipe/modwsgi/__init__.py
+++ b/collective/recipe/modwsgi/__init__.py
@@ -77,6 +77,7 @@ class Recipe(object):
             )
 
         target = self.options.get("target")
+
         if target is None:
             location = os.path.join(
                             self.buildout["buildout"]["parts-directory"],
@@ -86,11 +87,15 @@ class Recipe(object):
                 self.options.created(location)
             target = os.path.join(location, "wsgi")
         else:
-            self.options.created(target)
+            if os.path.lexists(target) and not os.path.exists(target):
+                # Can't write to a broken symlink, so remove it
+                os.unlink(target)
 
         f = open(target, "wt")
-        f.write(output)
-        f.close()
+        try:
+            f.write(output)
+        finally:
+            f.close()
 
         exec_mask = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
         os.chmod(target, os.stat(target).st_mode | exec_mask)


### PR DESCRIPTION
I used to create symbolic links to the wsgi script created by collective.recipe.modwsgi. To avoid this I recently started using the target option. However the recipe fails with an IOError when it tries to open a symlink of which the target does not exist.

I've created a little script that recreates my situation:

``` python
import os
from collective.recipe.modwsgi import Recipe

# Fake buildout
buildout = { 'buildout': { 'find-links': [],  'allow-hosts': '', 'eggs-directory': '', 'develop-eggs-directory': '' } }

# Fake options
class Options(dict):
    def created(self, *args):
        return
options = Options({'config-file': '', 'target': 'bin/test.wsgi', 'recipe': '' })

if not os.path.exists('parts'):
    os.mkdir('parts')
if not os.path.exists('bin'):
    os.mkdir('bin')
if os.path.lexists('bin/test.wsgi') or os.path.exists('bin/test.wsgi'):
    os.unlink('bin/test.wsgi')
os.symlink('./parts/DOESNOTEXIST', './bin/test.wsgi')

r = Recipe(buildout, '', options)
r.install()
```

The attached patch first removes a broken symlink if the target option is used.
