### PR TITLE
Add support for reading paste configuration file from environmental variable

### DIFF
--- a/collective/recipe/modwsgi/__init__.py
+++ b/collective/recipe/modwsgi/__init__.py
@@ -26,8 +26,13 @@ if sys.version_info >= (2, 6):
 else:
     from paste.script.util.logging_config import fileConfig
 
+from os import getenv
+configfile = getenv('PASTE_CONF_FILE')
+if not configfile:
+    configfile = %(config)r
+if not configfile:
+    raise RuntimeError("Paste configuration file has not been given neither in the buildout.cfg nor in the PASTE_CONF_FILE environmental variable")
 
-configfile = "%(config)s"
 try:
     fileConfig(configfile)
 except configparser.NoSectionError:
@@ -44,9 +49,8 @@ class Recipe(object):
         self.logger = logging.getLogger(self.name)
 
         if "config-file" not in options:
-            self.logger.error(
-                    "You need to specify either a paste configuration file")
-            raise zc.buildout.UserError("No paste configuration given")
+            self.logger.warning(
+                    "Paste configuration file not specified, remember to set the PASTE_CONF_FILE environmental variable on execution")
 
         if "target" in options:
             location = os.path.dirname(options["target"])
@@ -71,7 +75,7 @@ class Recipe(object):
             app_name = '"%s"' % app_name
 
         output = WRAPPER_TEMPLATE % dict(
-            config=self.options["config-file"],
+            config=self.options.get("config-file"),
             syspath=",\n    ".join((repr(p) for p in path)),
             app_name=app_name
             )


### PR DESCRIPTION
With this change the paste configuration file path can be unknown at buildout time.
In such case, the path will be read at run time from the environmental variable **PASTE_CONF_FILE**.
This is useful if you want to have just one script to be run with different configurations (by using e.g. the Apache directive **SetEnv**) or if you need to run a non daemonized server (e.g. `PASTE_CONF_FILE=production.ini apachectl -d . -f apache.conf -DFOREGROUND`)
An error is still raised if the user fails to set the path in either way.
User can also specify both, but the environment will take precedence.
The new version should be backward compatible.
